### PR TITLE
the proper OpenSSL use of Digest

### DIFF
--- a/lib/authorize_net/aim/response.rb
+++ b/lib/authorize_net/aim/response.rb
@@ -4,7 +4,7 @@ module AuthorizeNet::AIM
   class Response < AuthorizeNet::KeyValueResponse
     
     # Our MD5 digest generator.
-    @@digest = OpenSSL::Digest::Digest.new('md5')
+    @@digest = OpenSSL::Digest.new('md5')
     
     include AuthorizeNet::AIM::Fields
     

--- a/lib/authorize_net/sim/response.rb
+++ b/lib/authorize_net/sim/response.rb
@@ -5,7 +5,7 @@ module AuthorizeNet::SIM
   class Response < AuthorizeNet::KeyValueResponse
     
     # Our MD5 digest generator.
-    @@digest = OpenSSL::Digest::Digest.new('md5')
+    @@digest = OpenSSL::Digest.new('md5')
     
     include AuthorizeNet::SIM::Fields
     

--- a/lib/authorize_net/sim/transaction.rb
+++ b/lib/authorize_net/sim/transaction.rb
@@ -7,7 +7,7 @@ module AuthorizeNet::SIM
     RANDOM_SEQUENCE_MAX = (1 << 32) - 1
     
     # Our MD5 digest generator.
-    @@digest  = OpenSSL::Digest::Digest.new('md5')
+    @@digest  = OpenSSL::Digest.new('md5')
     
     # The default options for the constructor.
     @@option_defaults = {


### PR DESCRIPTION
This is the new way to use OpenSSL's Digest class without deprecation warnings from ruby 2.1+

In fact it's been the preferred method since ruby 1.8.x days.
