### PR TITLE
Check also for the presence of end sentinel

### DIFF
--- a/lib/authorize_net/payment_methods/credit_card.rb
+++ b/lib/authorize_net/payment_methods/credit_card.rb
@@ -53,22 +53,19 @@ module AuthorizeNet
         :exp_date => @expiration
       }
       hash[:card_code] = @card_code unless @card_code.nil?
-      unless @track_1.nil?
-        track_1 = @track_1
-        if track_1[0..0] == '%'
-          track_1 = track_1[1..(@track_1.rindex('?') - 1)]
-        end
-        hash[:track1] = track_1
-      end
-      unless @track_2.nil?
-        track_2 = @track_2
-        if track_2[0..0] == ';'
-          track_2 = track_2[1..(@track_2.rindex('?') - 1)]
-        end
-        hash[:track2] = track_2
-      end
+
+      hash[:track1] = strip_sentinels(@track_1, '%', '?') unless @track_1.nil?
+      hash[:track2] = strip_sentinels(@track_2, ';', '?') unless @track_2.nil?
       hash
     end
-    
+
+    def strip_sentinels(track, begin_sign, end_sign)
+      result = track
+      index = track.rindex(end_sign)
+      if result[0..0] == begin_sign && index.present?
+        result = result[1..(index - 1)]
+      end
+      result
+    end
   end
 end


### PR DESCRIPTION
This method causes 500 "undefined method '-' for nil" when user submit track_1 or track_2 value with beginning sentinel, but without the ending one. Submitting it to Authorize.net may result in proper transaction error, instead of 500.
I was thinking about removing sentinels one by one, but it may be a little overkill, especially because nobody noticed that error for at least a couple of years.
